### PR TITLE
missing a back tic on date

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var template = [
 	"",
 	"---",
 	"{{html_url}}  ",
-	"Created on `{{created_at}}"
+	"Created on `{{created_at}}`"
 ].join('\n');
 
 if(!fs.existsSync(process.env['HOME'] + '/.config/engist')) {


### PR DESCRIPTION
There was a missing back tick on the markdown for gist date of creation
